### PR TITLE
New auto hide sticky nav

### DIFF
--- a/src/scripts/_page_imports/content_template.ts
+++ b/src/scripts/_page_imports/content_template.ts
@@ -1,6 +1,7 @@
+import "../components/sticky_nav_alt";
+
 import "../components/accordion";
 import "../components/silo";
-import "../components/sticky_nav";
 import "../components/supernav";
 import "../components/lightbox";
 import "../components/related_select";

--- a/src/scripts/_page_imports/home.ts
+++ b/src/scripts/_page_imports/home.ts
@@ -1,2 +1,3 @@
-import "../components/sticky_nav";
+import "../components/sticky_nav_alt";
+
 import "../components/supernav";

--- a/src/scripts/components/sticky_nav.ts
+++ b/src/scripts/components/sticky_nav.ts
@@ -272,31 +272,41 @@ class StickyNav {
       this.parentClone.classList.contains('sticky-nav-show"') ||
       this.parentClone.classList.contains("sticky-nav-show-partial");
 
-    // Check partials
     if (this.currentTop >= realSupernavOffsetTop + realSupernavHeight) {
+      /**
+       * The nav has moved far enough for it
+       * to show either fully or partially
+       */
       if (isFastEnough && containsPartialClasses) {
+        /**
+         * The nav is moving fast enough and has
+         * been initialized.
+         */
         if (this.previousTop <= this.currentTop) {
-          // partial show
+          /**
+           * Scrolling down and partially showing the navigation
+           */
           this.parentClone.classList.add("sticky-nav-show-partial");
           this.parentClone.classList.remove("sticky-nav-show");
         } else {
-          // full show
+          /**
+           * Scrolling up and fully showing the navigation
+           */
           this.parentClone.classList.add("sticky-nav-show");
           this.parentClone.classList.remove("sticky-nav-show-partial");
         }
-      } else if (
-        (!containsPartialClasses && isFastEnough) ||
-        (!containsPartialClasses && !isFastEnough)
-      ) {
-        if (this.previousTop <= this.currentTop) {
-          // partial show
-          this.parentClone.classList.add("sticky-nav-show-partial");
-        } else {
-          // full show
-          this.parentClone.classList.add("sticky-nav-show");
-        }
+      } else if (!containsPartialClasses) {
+        /**
+         * The nav has NOT been initialzied
+         * At the very least this branch requires a partial show
+         */
+        this.parentClone.classList.add("sticky-nav-show-partial");
       }
     } else {
+      /**
+       * The navigation is at the top and should not show
+       * at all
+       */
       this.parentClone.classList.remove("sticky-nav-show-partial");
       this.parentClone.classList.remove("sticky-nav-show");
     }

--- a/src/scripts/components/sticky_nav.ts
+++ b/src/scripts/components/sticky_nav.ts
@@ -17,42 +17,47 @@
  *  - Increase DOM elements
  *  - Could have a performance impact on older devices
  */
+
 class StickyNav {
+  // Config
   realSupernavTag: string = "real-supernav";
   cloneSupernavTag: string = "cloned-supernav";
-  sticky: boolean = false;
 
+  // References
+  styleRef: HTMLStyleElement;
+
+  // Cloned elements
   parentClone: HTMLElement;
+  navBGClone: HTMLElement;
   logoClone: HTMLElement;
   supernavClone: HTMLElement;
+  bannerTextClone: HTMLElement;
+  bannerBGClone: HTMLElement;
+
+  // Meta Info
+  previousTop: number = window.scrollY;
+  currentTop: number = 0;
+  viewportWidth: number = window.innerWidth;
+  scrollThreshold: number = 50;
+  shouldShowSticky: boolean = false;
 
   constructor() {
-    this._createClassDefinitions();
     this._tagRealSupernav();
     this._createCompansatingStyles();
 
     this._createParentClone();
     this._createSuperNavClone();
     this._createLogoClone();
+    this._createBannerTextClone();
+    this._createBannerBGClone();
+    this._createNavBGClone();
+
+    this._createClassDefinitions();
 
     this._insertCloneElements();
 
     this._handleScroll();
-  }
-
-  private _createClassDefinitions() {
-    const style = document.createElement("style");
-    style.type = "text/css";
-
-    style.innerHTML = `
-      .sticky-nav-show { 
-          opacity: 1 !important;
-          transform: translateY(0px) !important;
-          pointer-events: auto !important;
-       }
-    `;
-
-    document.getElementsByTagName("head")[0].appendChild(style);
+    this._handleResizing();
   }
 
   private _tagRealSupernav() {
@@ -104,13 +109,12 @@ class StickyNav {
       `
         position: fixed;
         opacity: 0;
-        transform: translateY(-25px);
+        transform: translateY(-100%);
         top: 0px;
         left: 0px;
         right: 0px;
         z-index: 1000;
-        background-color: white;
-        border-bottom: 1px solid rgba(35, 31, 32, 0.10);
+        
         transition: all 150ms ease-in-out;
         pointer-events: none;
     `.replace(reqexNoSpace, "")
@@ -142,39 +146,195 @@ class StickyNav {
       .querySelector<HTMLDivElement>(".supernav")
       .cloneNode(true) as HTMLDivElement;
 
+    supernavClone.setAttribute(
+      "style",
+      `
+          z-index: 1;
+        `
+    );
+
     supernavClone.classList.remove(this.realSupernavTag);
     supernavClone.classList.add(this.cloneSupernavTag);
 
     this.supernavClone = supernavClone;
   }
 
+  private _createBannerTextClone() {
+    const bannerTextContainer = document
+      .querySelector<HTMLDivElement>(".banner-text")
+      .cloneNode(true) as HTMLDivElement;
+
+    bannerTextContainer.setAttribute(
+      "style",
+      `
+        z-index: -1;
+        grid-row-start: 3;
+        grid-row-end: 4;
+      `
+    );
+
+    this.bannerTextClone = bannerTextContainer as HTMLElement;
+  }
+
+  private _createBannerBGClone() {
+    const bannerBGContainer = document
+      .querySelector<HTMLDivElement>(".banner")
+      .cloneNode(true) as HTMLDivElement;
+
+    bannerBGContainer.setAttribute(
+      "style",
+      `
+        z-index: -1;
+        grid-row-start: 3;
+        grid-row-end: 4;
+      `
+    );
+
+    this.bannerBGClone = bannerBGContainer as HTMLElement;
+  }
+
+  private _createNavBGClone() {
+    const navBG = document.createElement("div");
+    // Removes tabs, new lines and double spaces
+    const reqexNoSpace = /(\r\n|\n|\r|\t|(\s\s+))/gm;
+
+    navBG.setAttribute(
+      "style",
+      `
+        background-color: white;
+        border-bottom: 1px solid rgba(35, 31, 32, 0.10);
+        z-index: 0;
+        grid-column-start: 1;
+        grid-column-end: -1;
+        grid-row-start: 1;
+        grid-row-end: -1;
+    `.replace(reqexNoSpace, "")
+    );
+
+    navBG.setAttribute("class", "navigation-layout");
+
+    this.navBGClone = navBG;
+  }
+
   private _insertCloneElements() {
     document.querySelector("body").prepend(this.parentClone);
 
+    this.parentClone.append(this.navBGClone);
     this.parentClone.append(this.supernavClone);
     this.parentClone.append(this.logoClone);
+    this.parentClone.append(this.bannerBGClone);
+    this.parentClone.append(this.bannerTextClone);
   }
 
-  private _scrollHandler() {
-    const realSupernavOffsetTop = document.querySelector<HTMLElement>(
-      `.supernav.${this.realSupernavTag}`
-    ).offsetTop;
+  private _createClassDefinitions() {
+    const supernav = document.querySelector(".supernav");
 
-    if (window.scrollY >= realSupernavOffsetTop && !this.sticky) {
-      this.sticky = true;
-      this.parentClone.classList.add("sticky-nav-show");
+    const stylesToInsert = `
+    .sticky-nav-show-partial {
+      opacity: 1 !important;
+      transform: translateY(-${
+        supernav.getBoundingClientRect().height
+      }px) !important;
+      pointer-events: auto !important;
     }
-    if (window.scrollY <= realSupernavOffsetTop && this.sticky) {
-      this.sticky = false;
+
+    .sticky-nav-show { 
+        opacity: 1 !important;
+        transform: translateY(0px) !important;
+        pointer-events: auto !important;
+     }
+  `;
+
+    if (this.styleRef) {
+      this.styleRef.innerHTML = stylesToInsert;
+    } else {
+      this.styleRef = document.createElement("style");
+      this.styleRef.type = "text/css";
+      this.styleRef.innerHTML = stylesToInsert;
+
+      document.getElementsByTagName("head")[0].appendChild(this.styleRef);
+    }
+  }
+
+  private _autoHideNavigation() {
+    const realSupernav = document.querySelector<HTMLElement>(
+      `.supernav.${this.realSupernavTag}`
+    );
+    const realSupernavOffsetTop = realSupernav.offsetTop;
+    const realSupernavHeight = realSupernav.getBoundingClientRect().height;
+
+    this.currentTop = window.scrollY;
+
+    const isFastEnough =
+      Math.abs(this.previousTop - this.currentTop) > this.scrollThreshold;
+
+    const containsPartialClasses =
+      this.parentClone.classList.contains('sticky-nav-show"') ||
+      this.parentClone.classList.contains("sticky-nav-show-partial");
+
+    // Check partials
+    if (this.currentTop >= realSupernavOffsetTop + realSupernavHeight) {
+      if (isFastEnough && containsPartialClasses) {
+        if (this.previousTop <= this.currentTop) {
+          // partial show
+          this.parentClone.classList.add("sticky-nav-show-partial");
+          this.parentClone.classList.remove("sticky-nav-show");
+        } else {
+          // full show
+          this.parentClone.classList.add("sticky-nav-show");
+          this.parentClone.classList.remove("sticky-nav-show-partial");
+        }
+      } else if (
+        (!containsPartialClasses && isFastEnough) ||
+        (!containsPartialClasses && !isFastEnough)
+      ) {
+        if (this.previousTop <= this.currentTop) {
+          // partial show
+          this.parentClone.classList.add("sticky-nav-show-partial");
+        } else {
+          // full show
+          this.parentClone.classList.add("sticky-nav-show");
+        }
+      }
+    } else {
+      this.parentClone.classList.remove("sticky-nav-show-partial");
       this.parentClone.classList.remove("sticky-nav-show");
+    }
+
+    this.previousTop = this.currentTop;
+  }
+
+  private _resizeHandler() {
+    // On mobile this will also fire on scrolling since the viewport height may change
+    if (this.viewportWidth !== window.innerWidth) {
+      this._createClassDefinitions();
+      this.viewportWidth = window.innerWidth;
     }
   }
 
   private _handleScroll() {
     // Initial run setup
-    this._scrollHandler();
+    this._autoHideNavigation();
 
-    window.addEventListener("scroll", this._scrollHandler.bind(this), {
+    let handler = () =>
+      !window.requestAnimationFrame
+        ? setTimeout(this._autoHideNavigation.bind(this), 250)
+        : requestAnimationFrame(this._autoHideNavigation.bind(this));
+
+    window.addEventListener("scroll", handler, {
+      passive: true,
+    });
+  }
+
+  private _handleResizing() {
+    this._resizeHandler();
+
+    let handler = () =>
+      !window.requestAnimationFrame
+        ? setTimeout(this._resizeHandler.bind(this), 250)
+        : requestAnimationFrame(this._resizeHandler.bind(this));
+
+    window.addEventListener("resize", handler, {
       passive: true,
     });
   }

--- a/src/scripts/components/sticky_nav_alt.ts
+++ b/src/scripts/components/sticky_nav_alt.ts
@@ -1,0 +1,217 @@
+/**
+ * NOTE:
+ * =====
+ * I'm simply cloning the contents of the actuall nav
+ * and then just injecting them. I want the entire script
+ * to handle the nav even the styling.
+ *
+ * This needs to be imported before the actual super nav
+ * to allow the script to also accound for the cloned
+ * element
+ *
+ * PROS:
+ *  - Just pulling the script would remove the feature
+ *  - Non intrusive (Kinda)
+ *
+ * CONS:
+ *  - Increase DOM elements
+ *  - Could have a performance impact on older devices
+ */
+
+class StickyNavAlt {
+  // Config
+  realSupernavTag: string = "real-supernav";
+  cloneSupernavTag: string = "cloned-supernav";
+
+  // References
+  styleClassDefRef: HTMLStyleElement;
+  styleCompansationDefRef: HTMLStyleElement;
+  navClone: HTMLElement;
+  navReal: HTMLElement;
+
+  // Meta Info
+  previousTop: number = window.scrollY;
+  currentTop: number = 0;
+  viewportWidth: number = window.innerWidth;
+  scrollThreshold: number = 25;
+
+  constructor() {
+    this._createClassDefinitions();
+    this._createCompansatingStyles();
+
+    this._cloneNav();
+
+    this._handleScroll();
+    this._handleResizing();
+  }
+
+  private _createClassDefinitions() {
+    const stylesToInsert = `
+      .navigation-clone {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        background: transparent;
+        z-index: 1000;
+        border-bottom: 1px solid transparent;
+        pointer-events: none;
+        transition: all 100ms ease-in-out;
+      }
+
+      .navigation-clone .supernav {
+        opacity: 0;
+        transform: translateY(-25px);
+        transition: all 150ms ease-in-out;
+      }
+
+      .navigation-clone .logo-container {
+        opacity: 0;
+        transform: translateY(-25px);
+        transition: all 150ms ease-in-out;
+      }
+
+      .sticky-nav-show {
+        background-color: white;
+        border-bottom-color: rgba(35, 31, 32, 0.10);
+        pointer-events: auto;
+      }
+
+      .sticky-nav-show.navigation-clone .supernav {
+        opacity: 1;
+        transform: translateY(0px);
+      }
+
+      .sticky-nav-show.navigation-clone .logo-container {
+        opacity: 1;
+        transform: translateY(0px);
+      }
+    `;
+
+    if (this.styleClassDefRef) {
+      this.styleClassDefRef.innerHTML = stylesToInsert;
+    } else {
+      this.styleClassDefRef = document.createElement("style");
+      this.styleClassDefRef.type = "text/css";
+      this.styleClassDefRef.innerHTML = stylesToInsert;
+
+      document
+        .getElementsByTagName("head")[0]
+        .appendChild(this.styleClassDefRef);
+    }
+  }
+
+  /**
+   * Some styles do not take into account
+   * the sticky nav. So I'm just compansating here
+   */
+  private _createCompansatingStyles() {
+    const defaultTopStyle = 16;
+    const navHeight = 72;
+
+    let stylesToInsert = ``;
+
+    /**
+     * SILO
+     * ========
+     */
+    stylesToInsert += `
+      @media (min-width: 1023px) {
+        #silo-container {
+          top: ${defaultTopStyle + navHeight}px !important;
+        }
+      }
+    `;
+
+    if (this.styleCompansationDefRef) {
+      this.styleCompansationDefRef.innerHTML = stylesToInsert;
+    } else {
+      this.styleCompansationDefRef = document.createElement("style");
+      this.styleCompansationDefRef.type = "text/css";
+      this.styleCompansationDefRef.innerHTML = stylesToInsert;
+
+      document
+        .getElementsByTagName("head")[0]
+        .appendChild(this.styleCompansationDefRef);
+    }
+  }
+
+  private _cloneNav() {
+    const bodyElement = document.body;
+    const navigationElement = document.querySelector(".navigation-layout");
+
+    const navigationClone = navigationElement.cloneNode(true);
+    const navigationCloneContainer = document.createElement("nav");
+
+    navigationCloneContainer.classList.add("navigation-clone");
+    navigationElement.parentElement.classList.add("navigation-real");
+
+    navigationCloneContainer.append(navigationClone);
+    bodyElement.prepend(navigationCloneContainer);
+
+    this.navClone = navigationCloneContainer;
+    this.navReal = navigationElement.parentElement;
+  }
+
+  private _autoHideNavigation() {
+    this.currentTop = window.scrollY;
+    const isFastEnough =
+      Math.abs(this.previousTop - this.currentTop) > this.scrollThreshold;
+
+    if (this.currentTop >= this.navReal.getBoundingClientRect().height) {
+      // Checking can now happen
+      if (isFastEnough) {
+        if (this.previousTop >= this.currentTop) {
+          this.navClone.classList.add("sticky-nav-show");
+        } else {
+          this.navClone.classList.remove("sticky-nav-show");
+        }
+      }
+    } else {
+      this.navClone.classList.remove("sticky-nav-show");
+    }
+
+    this.previousTop = this.currentTop;
+  }
+
+  private _resizeHandler() {
+    // On mobile this will also fire on scrolling since the viewport height may change
+    if (this.viewportWidth !== window.innerWidth) {
+      this._createClassDefinitions();
+      this.viewportWidth = window.innerWidth;
+    }
+  }
+
+  private _handleScroll() {
+    // Initial run setup
+    this._autoHideNavigation();
+
+    let handler = () =>
+      !window.requestAnimationFrame
+        ? setTimeout(this._autoHideNavigation.bind(this), 250)
+        : requestAnimationFrame(this._autoHideNavigation.bind(this));
+
+    window.addEventListener("scroll", handler, {
+      passive: true,
+    });
+  }
+
+  private _handleResizing() {
+    this._resizeHandler();
+
+    let handler = () =>
+      !window.requestAnimationFrame
+        ? setTimeout(this._resizeHandler.bind(this), 250)
+        : requestAnimationFrame(this._resizeHandler.bind(this));
+
+    window.addEventListener("resize", handler, {
+      passive: true,
+    });
+  }
+}
+
+try {
+  new StickyNavAlt();
+} catch (e) {
+  console.error(`Could not init Sticky Nav: ${e}`);
+}


### PR DESCRIPTION
The new sticky nav now has the ability to show and hide the main navigation but always have the banner information available. There are essentially 3 states the bar can be in: hidden, partially shown (just the banner) and fully show(Both banner and super nav).

## The three states on desktop:
### Fully hidden
![image](https://user-images.githubusercontent.com/36214317/135261754-24c880f9-02a1-4e1d-8405-2b47246a2ab7.png)

### Partially shown
![image](https://user-images.githubusercontent.com/36214317/135262004-676fc00a-2513-423d-9b7a-cf4f9bc1c37a.png)

### Fully shown
![image](https://user-images.githubusercontent.com/36214317/135262171-ec88e6ad-672a-46a6-b2e1-106fadc014f8.png)

## The three states on mobile:
### Fully hidden
![image](https://user-images.githubusercontent.com/36214317/135262500-c0d42331-e4f0-4bef-93eb-2a3157de9953.png)

### Partially shown
![image](https://user-images.githubusercontent.com/36214317/135262633-cc75b942-a88c-4330-a375-e3ec1530494e.png)

### Fully shown
![image](https://user-images.githubusercontent.com/36214317/135262738-e013fc9e-80a2-4bfa-8bf8-beee8fa9060e.png)


